### PR TITLE
Add project-level Claude Code skills

### DIFF
--- a/.claude/skills/dev-preview/SKILL.md
+++ b/.claude/skills/dev-preview/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: dev-preview
+description: Start the Vite dev server in the background so the site can be exercised in a browser, and report the URL for both entry points (main app and stickers). Use when the user asks to "run the site", "start dev", "preview my changes", or after a UI change that needs visual verification.
+---
+
+# dev-preview
+
+Bring up the local dev server and tell the user where to look.
+
+## What to run
+
+- `npm run dev` — starts Vite. Default URL is `http://localhost:5173/`.
+- The repo has **two HTML entry points** (see `vite.config.ts` and `AGENTS.md`):
+  - `http://localhost:5173/` → main app (root `#root`, full site, service workers unregistered on load)
+  - `http://localhost:5173/stickers.html` → stickers PWA-style entry (registers `stickers-sw.js`)
+- The app uses `HashRouter`, so deep links look like `http://localhost:5173/#/blog`, `/#/news`, `/#/stickers`.
+
+## Steps
+
+1. Start the dev server in the background (don't block on it):
+   - Use `Bash` with `run_in_background: true` so the user can continue interacting.
+2. Wait briefly for the server to be ready, then report:
+   - The base URL (`http://localhost:5173/`)
+   - Any specific deep link relevant to the change (e.g. `/#/blog/<NewSlug>` if a blog post was just added)
+   - The stickers URL only if the change touches stickers
+3. If the port is taken, Vite picks the next free one — read the background process output to get the actual URL before reporting it.
+4. When the user is done, kill the background process. **Don't leave dev servers running across sessions.**
+
+## When NOT to use
+
+- Don't start the dev server just to "check" something that `verify-build` would catch (TypeScript / lint errors). Use `verify-build` first; only spin up dev when the user actually needs to see the page render.
+- Don't start it for purely content edits to existing markdown files unless the user asked for a visual check.
+
+## Don't
+
+- Don't run `npm run preview` instead — that serves a built `dist/`, which requires a fresh `npm run build` and is rarely what the user wants while iterating.
+- Don't suggest opening URLs you haven't confirmed from the dev server's own output.

--- a/.claude/skills/new-blog-post/SKILL.md
+++ b/.claude/skills/new-blog-post/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: new-blog-post
+description: Scaffold a new blog post markdown file under src/content/blogs/ with the project's frontmatter format. Use when the user asks to "add a blog post", "write a new blog", "create a new article", or similar.
+---
+
+# new-blog-post
+
+Create a new blog post for this site.
+
+## Where the file goes
+
+- Path: `src/content/blogs/<Slug>.md`
+- The **filename without `.md` is the URL slug** — it appears in the route `/#/blog/<Slug>`. Use PascalCase or kebab-case, no spaces.
+- A new file is the only thing required; `src/utils/markdownLoader.ts` picks it up via `import.meta.glob` at build time. Do **not** edit any registry.
+
+## Required frontmatter
+
+Match the existing posts in `src/content/blogs/`. The parser in `markdownLoader.ts` reads simple `key: value` lines (no nested YAML).
+
+```markdown
+---
+layout: post
+title: <Human readable title>
+date: YYYY-MM-DD HH:MM:SS
+description: <One-sentence summary used as the excerpt>
+---
+
+<Body in GitHub-flavored markdown>
+```
+
+Notes:
+- `date` must parse with `new Date(...)` — posts are sorted newest-first by this field.
+- If `description` is omitted the loader falls back to the first ~150 chars of the body, but always include it.
+- Raw HTML inside the body works (rendered via `rehype-raw`) — useful for embedded iframes (see existing news posts).
+
+## Steps
+
+1. Confirm the slug with the user if it's not obvious from the request.
+2. Check `src/content/blogs/` to make sure the slug isn't already taken.
+3. Create the file with the frontmatter above and the user's content (or a placeholder body if they only gave a title).
+4. Do **not** modify `App.tsx`, `markdownLoader.ts`, or any list page — the new post will appear automatically.
+5. Mention the resulting URL: `/#/blog/<Slug>`.
+
+## Don't
+
+- Don't run `npm run build` just to "register" the post — the glob picks it up at dev/build time on its own.
+- Don't add fields the loader doesn't read (e.g. `tags`, `categories`) unless the user asks; they'll be silently dropped.

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: new-component
+description: Scaffold a new reusable React component under src/components/ following the project's MUI v7 + Framer Motion + TypeScript conventions. Use when the user asks to "add a component", "extract this into a component", or "create a reusable X".
+---
+
+# new-component
+
+Add a new reusable component to `src/components/`.
+
+## Conventions in this repo
+
+- One component per file. Filename = `PascalCase.tsx` and matches the exported component name.
+- Default export of the component. Props declared as a typed interface, not inline.
+- UI primitives come from **MUI v7** (`@mui/material`, `@mui/icons-material`). Don't add a new component library.
+- Animations use **Framer Motion** when needed (see `AnimatedCard.tsx`, `HeroSection.tsx`).
+- Styling: prefer MUI's `sx` prop; use Emotion `styled(...)` only when the component is already complex enough to warrant it (look at sibling files for examples).
+- No CSS modules, no Tailwind — global styles live in `src/index.css` / `src/App.css` only.
+
+## Template
+
+```tsx
+import { Box, Typography } from '@mui/material';
+
+interface <Name>Props {
+  // ...required props
+}
+
+const <Name>: React.FC<<Name>Props> = ({ /* destructure props */ }) => {
+  return (
+    <Box sx={{ /* ... */ }}>
+      <Typography variant="body1">{/* ... */}</Typography>
+    </Box>
+  );
+};
+
+export default <Name>;
+```
+
+## Steps
+
+1. Skim 1–2 nearby components (e.g. `src/components/FeatureCard.tsx`, `src/components/SkillChip.tsx`) so the new file matches their density and style. **Do this before writing — don't invent a new pattern.**
+2. Create `src/components/<Name>.tsx`.
+3. If the component has a non-obvious public surface, expose props through a typed `interface`, not `type` aliases or inline object types — the rest of the codebase uses `interface`.
+4. Import from the new component in the requested call-site, if the user named one.
+5. After substantial UI work, run `npm run build` (or use `verify-build`) to catch type errors before declaring done.
+
+## Don't
+
+- Don't add a new dependency for something MUI already provides (icons, layout, typography, dialogs, etc.).
+- Don't create an `index.ts` barrel file in `src/components/` — the project imports from each file directly.
+- Don't write multi-paragraph JSDoc on simple components; the repo style is terse.

--- a/.claude/skills/new-news-post/SKILL.md
+++ b/.claude/skills/new-news-post/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: new-news-post
+description: Scaffold a new news / timeline entry under src/content/news/ with the project's frontmatter format. Use when the user asks to "add a news item", "post an update", "log a life event", or similar short-form entry.
+---
+
+# new-news-post
+
+Create a new news entry — these are the short, dated items that appear on the news / timeline page.
+
+## Where the file goes
+
+- Path: `src/content/news/<Slug>.md`
+- The **filename without `.md` is the URL slug** — route is `/#/news/<Slug>`.
+- The new file is auto-discovered by `src/utils/markdownLoader.ts` (no registry edit needed).
+
+## Required frontmatter
+
+Mirror the existing news files (e.g. `src/content/news/JoinedTrivago.md`):
+
+```markdown
+---
+layout: post
+title: <Short title>
+date: YYYY-MM-DD HH:MM:SS-ZZZZ
+inline: true
+related_posts: false
+---
+
+<Short body — markdown + raw HTML allowed (rehype-raw is enabled)>
+```
+
+Notes:
+- `date` must be `new Date(...)`-parseable; posts are sorted newest-first.
+- `inline: true` and `related_posts: false` are conventions kept across existing news entries — preserve them unless the user explicitly wants different behavior.
+- The loader truncates the excerpt to ~20 chars when `description` is missing, so news items don't need a `description` field.
+- For embedded video, use the same responsive `<iframe>` wrapper used in `JoinedTrivago.md`.
+
+## Steps
+
+1. Confirm the slug if not obvious; check `src/content/news/` for collisions.
+2. Create the file with frontmatter above and the user's content.
+3. Do **not** edit `App.tsx`, `markdownLoader.ts`, or any list page.
+4. Tell the user the resulting URL: `/#/news/<Slug>`.
+
+## Don't
+
+- Don't add a long-form essay here — those belong in `src/content/blogs/`. If the user's content runs more than a few paragraphs, ask whether they meant a blog post instead.

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: new-page
+description: Scaffold a new top-level React page under src/pages/ and wire it into the route table in src/App.tsx. Use when the user wants to "add a new page", "create a /something route", or "add a section to the site".
+---
+
+# new-page
+
+Add a new top-level page to the site.
+
+## Files involved
+
+- Create: `src/pages/<PageName>Page.tsx`
+- Edit: `src/App.tsx` — add a `<Route>` inside the existing `<Route path="/" element={<MainLayout />}>` block, **above** the catch-all `path="*"` route.
+
+## Routing notes
+
+- The app uses `HashRouter` (see `src/main.tsx`), so the user-facing URL will be `/#/<path>`.
+- Don't put the new route outside the `MainLayout` wrapper unless the user explicitly wants a layout-less page (e.g. like the separate `stickers.html` entry).
+- The catch-all `path="*"` must remain **last**.
+
+## Page template
+
+Match the existing pages in `src/pages/` — MUI v7 + Framer Motion conventions. Minimal scaffold:
+
+```tsx
+import { Box, Container, Typography } from '@mui/material';
+import { motion } from 'framer-motion';
+
+const <PageName>Page: React.FC = () => {
+  return (
+    <Container maxWidth="md" sx={{ py: 6 }}>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <Box>
+          <Typography variant="h3" gutterBottom>
+            <PageName>
+          </Typography>
+          {/* content */}
+        </Box>
+      </motion.div>
+    </Container>
+  );
+};
+
+export default <PageName>Page;
+```
+
+## Steps
+
+1. Confirm the page name and URL path with the user if ambiguous.
+2. Look at a sibling page (e.g. `src/pages/BlogPage.tsx`) before writing — copy its style, spacing, and animation conventions instead of inventing new ones.
+3. Create `src/pages/<PageName>Page.tsx`.
+4. In `src/App.tsx`:
+   - Add `import <PageName>Page from './pages/<PageName>Page';` with the other page imports.
+   - Add `<Route path="<url-path>" element={<<PageName>Page />} />` **above** the `path="*"` line.
+5. Run `npm run build` (or use the `verify-build` skill) to catch typing/route mistakes.
+
+## Don't
+
+- Don't switch the app to `BrowserRouter` — `HashRouter` is intentional for GitHub Pages hosting (see `AGENTS.md`).
+- Don't create a new HTML entry in `vite.config.ts` unless the user wants a fully separate bundle like `stickers.html`.

--- a/.claude/skills/verify-build/SKILL.md
+++ b/.claude/skills/verify-build/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: verify-build
+description: Run lint and the production Vite build to catch TypeScript and bundling errors before reporting a task done. Use after non-trivial UI, route, or utility changes — and any time the user asks to "check the build", "make sure it compiles", or "run the checks".
+---
+
+# verify-build
+
+Run the project's static checks the same way CI does.
+
+## Commands (run in this order)
+
+1. `npm run lint` — ESLint over the repo (config: `eslint.config.js`, includes `react-hooks` and `react-refresh` plugins).
+2. `npm run build` — `vite build`. This is what catches TypeScript errors; there is **no separate `tsc`/typecheck script**.
+
+Both should exit 0. CI runs on **Node 20** with `npm ci` (see `.github/workflows/deploy.yml`); local Node should be on a similar major.
+
+## Steps
+
+1. Run `npm run lint`. If it fails, fix the issues (or surface them clearly) before continuing — don't ignore lint to push through.
+2. Run `npm run build`. Output goes to `dist/`.
+3. If the build fails, read the error: TypeScript errors usually point at a specific `src/...` file:line — fix at the source rather than loosening `tsconfig.json`.
+4. Report the outcome to the user: lint pass/fail, build pass/fail, and any meaningful warnings.
+
+## Don't
+
+- Don't run `npm install` unless `node_modules` is genuinely missing or `package.json` was edited — it's slow and not needed for verification.
+- Don't add a `tsc --noEmit` step or a new `typecheck` script unless the user asks; `vite build` already type-checks.
+- Don't suppress errors with `// @ts-ignore`, `eslint-disable`, or `--no-verify` to make checks pass. Fix the root cause.
+- Don't deploy or push — deployment is automatic from `main` via GitHub Actions.


### PR DESCRIPTION
## Summary

Adds six project-scoped skills under `.claude/skills/` so future Claude Code sessions on this repo can invoke common blog workflows as slash commands without re-deriving the project's conventions each time.

## What's added

Content authoring:
- `/new-blog-post` — scaffold `src/content/blogs/<Slug>.md` with the frontmatter format `markdownLoader.ts` parses (`layout`, `title`, `date`, `description`).
- `/new-news-post` — same for `src/content/news/`, preserving the `inline: true` / `related_posts: false` convention used by existing entries.

Code scaffolding:
- `/new-page` — create `src/pages/<X>Page.tsx` and wire it into `App.tsx` above the `path="*"` catch-all. Notes that `HashRouter` is intentional for GitHub Pages.
- `/new-component` — MUI v7 + Framer Motion component template with explicit "read a sibling first" guidance.

Verification:
- `/verify-build` — runs `npm run lint` then `npm run build` (build is the typecheck — there's no separate `tsc` script). Rule: fix the source, don't suppress.
- `/dev-preview` — starts `npm run dev` in the background, reports both entry-point URLs (main app + `stickers.html`), reminds to kill the server after.

## Why

Each skill encodes the non-obvious bits documented in `AGENTS.md` (HashRouter, Vite multi-entry, S3 stickers, markdown auto-discovery via `import.meta.glob`) so a future agent doesn't need to re-read the whole repo just to add a blog post or a route.

## Test plan

- [ ] Skills appear in the available-skills list when starting a new Claude Code session in this repo
- [ ] `/new-blog-post` produces a file the dev server picks up at `/#/blog/<Slug>` without other edits
- [ ] `/new-page` adds the import + `<Route>` in the right place in `src/App.tsx`
- [ ] `/verify-build` exits cleanly on the current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)