### PR TITLE
fix: enforce square aspect ratio on sticker cards

### DIFF
--- a/src/components/StickerCard.tsx
+++ b/src/components/StickerCard.tsx
@@ -34,6 +34,7 @@ const StickerCard: React.FC<StickerCardProps> = ({ sticker, delay = 0 }) => {
             image={sticker.url}
             alt={sticker.name}
             sx={{
+              aspectRatio: '1 / 1',
               objectFit: 'contain',
               padding: 2,
               backgroundColor: (theme) => 


### PR DESCRIPTION
## Summary
- Sticker cards in the `/stickers` page displayed at varying heights depending on each image's natural aspect ratio, leaving awkward blank space below portrait-oriented stickers (visible in the screenshot with the Minions card).
- Added `aspectRatio: '1 / 1'` to the `CardMedia` `sx` prop in `StickerCard.tsx` so every card renders as a uniform square, with images centered via the existing `objectFit: 'contain'`.

## Test plan
- [ ] Open `/stickers` page and confirm all cards form a uniform square grid
- [ ] Verify portrait, landscape, and square images all fit neatly without clipping or blank strips
- [ ] Check dark mode — background fill still shows correctly in the padded area

🤖 Generated with [Claude Code](https://claude.com/claude-code)