### PR TITLE
fix: keep audio button inline at end of name on mobile

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -34,21 +34,23 @@ const HeroSection: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5 }}
             >
-              <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+              <Box sx={{ display: 'block', mb: 1 }}>
                 <Typography
                   component="h1"
                   variant="h2"
                   color="white"
                   fontWeight="bold"
                   gutterBottom
-                  sx={{ mr: 1 }}
+                  sx={{ display: 'inline', mr: 1 }}
                 >
                   Hello, I'm ZhongLi Shen(沈仲黎)
                 </Typography>
-                <AudioPlayer 
-                  audioFile="/assets/audio/myname.wav" 
-                  tooltipText="Hear how to pronounce my name"
-                />
+                <Box component="span" sx={{ display: 'inline-flex', verticalAlign: 'middle' }}>
+                  <AudioPlayer
+                    audioFile="/assets/audio/myname.wav"
+                    tooltipText="Hear how to pronounce my name"
+                  />
+                </Box>
               </Box>
             </motion.div>
             


### PR DESCRIPTION
## Summary

- On narrow/mobile screens the pronunciation audio button was wrapping to a second line below the name heading
- Changed the layout from a `flex` row (which allows wrapping) to inline text flow: `Typography` is now `display: inline` and `AudioPlayer` is wrapped in an `inline-flex` span with `verticalAlign: middle`
- The speaker icon now always appears directly after "(沈仲黎)" regardless of how the heading text wraps

## Test plan

- [ ] View hero section on a narrow viewport (~375px) and confirm the audio button sits at the end of the name text, not on a separate line
- [ ] Verify the button still aligns vertically with the text on desktop
- [ ] Confirm the audio still plays correctly when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)